### PR TITLE
Remove '--ro-bind /nix /nix' from bubblewrap options

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -288,6 +288,7 @@ let
         ${optionalString unshareUts "--unshare-uts"}
         ${optionalString unshareCgroup "--unshare-cgroup"}
         ${optionalString dieWithParent "--die-with-parent"}
+        --bind /nix /nix
         ${optionalString privateTmp "--tmpfs /tmp"}
         # Our glibc will look for the cache in its own path in `/nix/store`.
         # As such, we need a cache to exist there, because pressure-vessel

--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -288,7 +288,6 @@ let
         ${optionalString unshareUts "--unshare-uts"}
         ${optionalString unshareCgroup "--unshare-cgroup"}
         ${optionalString dieWithParent "--die-with-parent"}
-        --ro-bind /nix /nix
         ${optionalString privateTmp "--tmpfs /tmp"}
         # Our glibc will look for the cache in its own path in `/nix/store`.
         # As such, we need a cache to exist there, because pressure-vessel


### PR DESCRIPTION
Removed the '--ro-bind /nix /nix' option from the bubblewrap command.

Explanation: There are two ways to setup Nix:
1. Single-user: In this mode the nix operations operate directly on the /nix/store - this way nix is virtually independent of the host.
2. Multi-user mode: In this mode all operations on the /nix/store are mediated through a nix-daemon. This prevents malicious code injections in a multi user setup. 

The FHSEnv mounts the /nix/store as read-only. That is fine in a multi-user install since all operations inside the Env get passed through the daemon which runs on the host and has write-access. 

In a single-user install the /nix/store needs to be mounted read-only to be able to be able to use nix inside the Env. This effectively makes nix inside and outside the Env identical. 

This potentially has some minor side effects where the daemon would usually perform further separation for commands from within an Env (e.g. clean-up of the store). As far as I can tell nothing that should be relevant for our use cases.

(NB: Multi-user mode requires running a daemon and setting up special user groups. It is therefore incompatible with a portable installation of Nix)